### PR TITLE
Changed to 'python3' in launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The code is an example of implementing a custom MovieOS-style interface for your
 
 ```
 cd /home/pi/rpi_lcars/app
-sudo -u pi xinit /usr/bin/python lcars.py
+sudo -u pi xinit /usr/bin/python3 lcars.py
 ``` 
 The above assumes you want to run the interface from the ```/home/pi/rpi_lcars``` folder as the ```pi``` user. To run as root, simply omit the ```sudo -u pi``` bit.
 


### PR DESCRIPTION
Seeing as this uses python3 we should be sure to get the correct one.